### PR TITLE
Fix types of GridPosition method parameters

### DIFF
--- a/source/.gitignore
+++ b/source/.gitignore
@@ -1,0 +1,3 @@
+*.swp
+*.swo
+game

--- a/source/Agents/PacingAgent.hpp
+++ b/source/Agents/PacingAgent.hpp
@@ -14,7 +14,7 @@ namespace cse491 {
 
   class PacingAgent : public AgentBase {
   protected:
-    bool vertical=false; ///< Is this agent moving down&up?  False = right&left.
+    bool vertical=true; ///< Is this agent moving down&up?  False = right&left.
     bool reverse=false;  ///< Is this agent on their way back? (up/left?)
 
   public:

--- a/source/Interfaces/TrashInterface.hpp
+++ b/source/Interfaces/TrashInterface.hpp
@@ -55,7 +55,11 @@ namespace cse491 {
 
       for (const auto & agent_ptr : agent_set) {
         GridPosition pos = agent_ptr->GetPosition();
-        symbol_grid[pos.CellY()][pos.CellX()] = '*';
+        char c = '*';
+        if(agent_ptr->HasProperty("char")){
+          c = static_cast<char>(agent_ptr->GetProperty("char"));
+        }
+        symbol_grid[pos.CellY()][pos.CellX()] = c;
       }
 
       // Print out the symbol_grid

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,0 +1,4 @@
+default:
+	g++ simple_main.cpp -std=c++20 -o game
+clean:
+	rm game

--- a/source/core/GridPosition.hpp
+++ b/source/core/GridPosition.hpp
@@ -56,10 +56,10 @@ namespace cse491 {
     [[nodiscard]] GridPosition GetOffset(double x_offset, double y_offset) const {
       return GridPosition{x+x_offset,y+y_offset};
     }
-    [[nodiscard]] GridPosition Above(size_t dist=1.0) const { return GetOffset(0.0, -dist); }
-    [[nodiscard]] GridPosition Below(size_t dist=1.0) const { return GetOffset(0.0, dist); }
-    [[nodiscard]] GridPosition ToLeft(size_t dist=1.0) const { return GetOffset(-dist, 0.0); }
-    [[nodiscard]] GridPosition ToRight(size_t dist=1.0) const { return GetOffset(dist, 0.0); }
+    [[nodiscard]] GridPosition Above(double dist=1.0) const { return GetOffset(0.0, -dist); }
+    [[nodiscard]] GridPosition Below(double dist=1.0) const { return GetOffset(0.0, dist); }
+    [[nodiscard]] GridPosition ToLeft(double dist=1.0) const { return GetOffset(-dist, 0.0); }
+    [[nodiscard]] GridPosition ToRight(double dist=1.0) const { return GetOffset(dist, 0.0); }
   };
 
 } // End of namespace cse491

--- a/source/simple_main.cpp
+++ b/source/simple_main.cpp
@@ -14,6 +14,6 @@ int main()
   cse491::MazeWorld world;
   world.AddAgent<cse491::PacingAgent>("Pacer 1").SetPosition(2,1);
   world.AddAgent<cse491::PacingAgent>("Pacer 2").SetPosition(4,1);
-  world.AddAgent<cse491::TrashInterface>("Interface");
+  world.AddAgent<cse491::TrashInterface>("Interface").SetProperty("char", '@');
   world.Run();
 }

--- a/source/simple_main.cpp
+++ b/source/simple_main.cpp
@@ -12,7 +12,7 @@
 int main()
 {
   cse491::MazeWorld world;
-  world.AddAgent<cse491::PacingAgent>("Pacer 1");
+  world.AddAgent<cse491::PacingAgent>("Pacer 1").SetPosition(2,1);
   world.AddAgent<cse491::PacingAgent>("Pacer 2").SetPosition(4,1);
   world.AddAgent<cse491::TrashInterface>("Interface");
   world.Run();


### PR DESCRIPTION
`GridPosition` methods `.Above`, `.Below`, `.ToLeft`, `.ToRight` all took `size_t` distances. 
These `size_t` distances were then multiplied by negative one in `.Above` and `.ToLeft`. `size_t` cannot handle negative numbers and thus we end up with very large positive numbers. 

To fix this, we switch the distance parameters `double`. Since these methods are returning offsets of `x` and `y`, which are `double`s, this makes the types consistent throughout. 

Also I added a `Makefile` and `.gitignore` to make life easier, and switched the PacingAgents to move vertically in their own columns of the map. Further, I swapped the player's symbol to `@` to show of entity properties. 