### PR TITLE
Removed undefined behavior from WorldGrid

### DIFF
--- a/source/core/WorldGrid.hpp
+++ b/source/core/WorldGrid.hpp
@@ -71,13 +71,13 @@ namespace cse491 {
     [[nodiscard]] size_t GetNumCells() const { return cells.size(); }
 
     /// Test if specific coordinates are in range for this GridWorld.
-    [[nodiscard]] bool IsValid(size_t x, size_t y) const {
-      return x < width && y < height;
+    [[nodiscard]] bool IsValid(double x, double y) const {
+      return x >= 0.0 && x < width && y >= 0.0 && y < height;
     }
 
     /// Test if a GridPosition is in range for this GridWorld.
     [[nodiscard]] bool IsValid(GridPosition pos) const {
-      return IsValid(pos.CellX(), pos.CellY());
+      return IsValid(pos.GetX(), pos.GetY());
     }
 
     /// @return The grid state at the provided x and y coordinates


### PR DESCRIPTION
World grid was converting doubles to size_t, which is undefined if the double is negative.  Now all checks are done on the original double values.

