### PR TITLE
Add missing cd in run_tests.sh

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,6 +20,7 @@ if [ -d ${TARGET} ]
     cd ${TARGET}
     run_tests
     echo "Exiting ${TARGET}"
+    cd ..
   else
     echo "Directory not found: ${TARGET}. Skipping."
   fi


### PR DESCRIPTION
Fixes an issue where the script does not make it back out of particular unit test directories (shoutout Richard for catching this!)