### PR TITLE
Created a logging class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,11 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 
 # all the possible executables [each team can have their own configuration]
 # copy over simple or same and change the accordingly
-set(EXECUTABLES simple sfml_example)
+set(EXECUTABLES
+        simple
+        sfml_example
+        Logging
+)
 
 
 # setting the output path to executable
@@ -29,9 +33,10 @@ set(SFML_BUILD_DIR sfml_build)
 set(MAIN_SOURCE_DIR ./)
 add_subdirectory(${SFML_SRC_DIR} ${SFML_BUILD_DIR})
 
+set(EASY_LOGGING source/core/EasyLogging.hpp)
 
 foreach(EXECUTABLE ${EXECUTABLES})
-    set(SOURCES source/${EXECUTABLE}_main.cpp)
+    set(SOURCES source/${EXECUTABLE}_main.cpp ${EASY_LOGGING})
     add_executable(${EXECUTABLE} ${SOURCES})
     target_include_directories(${EXECUTABLE}
       PRIVATE ${MAIN_SOURCE_DIR}

--- a/source/Logging_main.cpp
+++ b/source/Logging_main.cpp
@@ -3,16 +3,35 @@
 
 
 int main() {
-    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << Logger::endl;
-    Logger::log << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << Logger::endl;
-    Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << Logger::endl;
-    Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
-    Logger::log << "cont no endl Error message from Team";
-    Logger::log << Team::TEAM_6 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
-    Logger::log << "This is wi." << Logger::endl;
-    Logger::log << "This is wi." << Logger::endl;
-    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message from Team C." << Logger::endl;
-    Logger::log << Team::TEAM_5 << LogLevel::ERROR << "Error message from Team C." << Logger::endl;
+//    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << Logger::endl;
+//    Logger::log << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << Logger::endl;
+//    Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << Logger::endl;
+//    Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
+//    Logger::log << "cont no endl Error message from Team";
+//    Logger::log << Team::TEAM_6 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
+//    Logger::log << "This is wi." << Logger::endl;
+//    Logger::log << "This is wi." << Logger::endl;
+//    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message from Team C." << Logger::endl;
+//    Logger::log << Team::TEAM_5 << LogLevel::ERROR << "Error message from Team C." << Logger::endl;
+//
+
+    // Example 1: Logging a debug message for Team 1 in blue color
+    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "Debug message for Team 1" << Logger::endl;
+
+    // Example 2: Logging an error message for Team 5 in red color
+    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message for Team 5" << Logger::endl;
+
+    // Example 3: Logging an info message for General team in green color
+    Logger::log << Team::GENERAL << LogLevel::INFO << Color::GREEN << "Info message for General team" << Logger::endl;
+
+    // Example 4: Logging a warning message without specifying team and color
+    Logger::log << LogLevel::WARNING << "Generic warning message level Warning" << Logger::endl;
+
+    // Example 4: Logging a warning message without specifying team and color
+    Logger::log << LogLevel::NA  << "Generic warning message" << Logger::endl;
+
+
+
 
     return 0;
 }

--- a/source/Logging_main.cpp
+++ b/source/Logging_main.cpp
@@ -3,32 +3,32 @@
 
 
 int main() {
-//    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << Logger::endl;
-//    Logger::log << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << Logger::endl;
-//    Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << Logger::endl;
-//    Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
-//    Logger::log << "cont no endl Error message from Team";
-//    Logger::log << Team::TEAM_6 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
-//    Logger::log << "This is wi." << Logger::endl;
-//    Logger::log << "This is wi." << Logger::endl;
-//    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message from Team C." << Logger::endl;
-//    Logger::log << Team::TEAM_5 << LogLevel::ERROR << "Error message from Team C." << Logger::endl;
+    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << Logger::endl;
+    Logger::log << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << Logger::endl;
+    Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << Logger::endl;
+    Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
+    Logger::log << "cont no endl Error message from Team";
+    Logger::log << Team::TEAM_6 << LogLevel::ERROR << Color::GREEN << "Error message from Team C. no endl";
+    Logger::log << "This is wi." << Logger::endl;
+    Logger::log << "This is wi." << Logger::endl;
+    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message from Team C." << Logger::endl;
+    Logger::log << Team::TEAM_5 << LogLevel::ERROR << "Error message from Team C." << Logger::endl;
 //
 
-    // Example 1: Logging a debug message for Team 1 in blue color
-    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "Debug message for Team 1" << Logger::endl;
-
-    // Example 2: Logging an error message for Team 5 in red color
-    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message for Team 5" << Logger::endl;
-
-    // Example 3: Logging an info message for General team in green color
-    Logger::log << Team::GENERAL << LogLevel::INFO << Color::GREEN << "Info message for General team" << Logger::endl;
-
-    // Example 4: Logging a warning message without specifying team and color
-    Logger::log << LogLevel::WARNING << "Generic warning message level Warning" << Logger::endl;
-
-    // Example 4: Logging a warning message without specifying team and color
-    Logger::log << LogLevel::NA  << "Generic warning message" << Logger::endl;
+//    // Example 1: Logging a debug message for Team 1 in blue color
+//    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "Debug message for Team 1" << Logger::endl;
+//
+//    // Example 2: Logging an error message for Team 5 in red color
+//    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message for Team 5" << Logger::endl;
+//
+//    // Example 3: Logging an info message for General team in green color
+//    Logger::log << Team::GENERAL << LogLevel::INFO << Color::GREEN << "Info message for General team" << Logger::endl;
+//
+//    // Example 4: Logging a warning message without specifying team and color
+//    Logger::log << LogLevel::WARNING << "Generic warning message level Warning" << Logger::endl;
+//
+//    // Example 4: Logging a warning message without specifying team and color
+//    Logger::log << LogLevel::NA  << "Generic warning message" << Logger::endl;
 
 
 

--- a/source/Logging_main.cpp
+++ b/source/Logging_main.cpp
@@ -5,38 +5,36 @@
 using namespace clogged;
 
 void samplefunction() {
-    Logger::log << LOG_FNC << "This log message includes file and line number." << std::endl;
+    Logger::Log() << LOG_FNC << "This Log() message includes file and line number." << std::endl;
 }
 
 
 int main() {
-    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << std::endl;
-    Logger::log << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << std::endl;
-    Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << std::endl;
-    Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
-    Logger::log << "cont no endl Error message from Team";
+    Logger::Log() << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << std::endl;
+    Logger::Log() << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << std::endl;
+    Logger::Log() << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << std::endl;
+    Logger::Log() << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
+    Logger::Log() << "cont no endl Error message from Team";
 
-    Logger::log << std::endl <<  "Warning message standard overload" << std::endl;
+    Logger::Log() << std::endl <<  "Warning message standard overload" << std::endl;
 
     samplefunction();
 
 
-
-
 //    // Example 1: Logging a debug message for Team 1 in blue color
-//    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "Debug message for Team 1" << Logger::endl;
+//    Logger::Log() << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "Debug message for Team 1" << Logger::endl;
 //
 //    // Example 2: Logging an error message for Team 5 in red color
-//    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message for Team 5" << Logger::endl;
+//    Logger::Log() << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message for Team 5" << Logger::endl;
 //
 //    // Example 3: Logging an info message for General team in green color
-//    Logger::log << Team::GENERAL << LogLevel::INFO << Color::GREEN << "Info message for General team" << Logger::endl;
+//    Logger::Log() << Team::GENERAL << LogLevel::INFO << Color::GREEN << "Info message for General team" << Logger::endl;
 //
 //    // Example 4: Logging a warning message without specifying team and color
-//    Logger::log << LogLevel::WARNING << "Generic warning message level Warning" << Logger::endl;
+//    Logger::Log() << LogLevel::WARNING << "Generic warning message level Warning" << Logger::endl;
 //
 //    // Example 4: Logging a warning message without specifying team and color
-//    Logger::log << LogLevel::NA  << "Generic warning message" << Logger::endl;
+//    Logger::Log() << LogLevel::NA  << "Generic warning message" << Logger::endl;
 
 
 

--- a/source/Logging_main.cpp
+++ b/source/Logging_main.cpp
@@ -1,0 +1,18 @@
+
+#include "./core/EasyLogging.hpp"
+
+
+int main() {
+    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << Logger::endl;
+    Logger::log << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << Logger::endl;
+    Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << Logger::endl;
+    Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
+    Logger::log << "cont no endl Error message from Team";
+    Logger::log << Team::TEAM_6 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
+    Logger::log << "This is wi." << Logger::endl;
+    Logger::log << "This is wi." << Logger::endl;
+    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message from Team C." << Logger::endl;
+    Logger::log << Team::TEAM_5 << LogLevel::ERROR << "Error message from Team C." << Logger::endl;
+
+    return 0;
+}

--- a/source/Logging_main.cpp
+++ b/source/Logging_main.cpp
@@ -1,6 +1,10 @@
 
 #include "./core/EasyLogging.hpp"
 
+void samplefunction() {
+    Logger::log << FUNCTION_NAME << "This log message includes file and line number." << Logger::endl;
+}
+
 
 int main() {
     Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << Logger::endl;
@@ -8,12 +12,13 @@ int main() {
     Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << Logger::endl;
     Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
     Logger::log << "cont no endl Error message from Team";
-    Logger::log << Team::TEAM_6 << LogLevel::ERROR << Color::GREEN << "Error message from Team C. no endl";
-    Logger::log << "This is wi." << Logger::endl;
-    Logger::log << "This is wi." << Logger::endl;
-    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message from Team C." << Logger::endl;
-    Logger::log << Team::TEAM_5 << LogLevel::ERROR << "Error message from Team C." << Logger::endl;
-//
+
+    Logger::log << std::endl <<  "Warning message standard overload" << Logger::endl;
+
+    samplefunction();
+
+
+
 
 //    // Example 1: Logging a debug message for Team 1 in blue color
 //    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "Debug message for Team 1" << Logger::endl;

--- a/source/Logging_main.cpp
+++ b/source/Logging_main.cpp
@@ -5,7 +5,7 @@
 using namespace clogged;
 
 void samplefunction() {
-    std::log << LOG_FNC << "This log message includes file and line number." << std::endl;
+    Logger::log << LOG_FNC << "This log message includes file and line number." << std::endl;
 }
 
 

--- a/source/Logging_main.cpp
+++ b/source/Logging_main.cpp
@@ -1,8 +1,11 @@
 
 #include "./core/EasyLogging.hpp"
 
+
+using namespace clogged;
+
 void samplefunction() {
-    Logger::log << FUNCTION_NAME << "This log message includes file and line number." << Logger::endl;
+    Logger::log << LOG_FNC << "This log message includes file and line number." << Logger::endl;
 }
 
 

--- a/source/Logging_main.cpp
+++ b/source/Logging_main.cpp
@@ -5,18 +5,18 @@
 using namespace clogged;
 
 void samplefunction() {
-    Logger::log << LOG_FNC << "This log message includes file and line number." << Logger::endl;
+    std::log << LOG_FNC << "This log message includes file and line number." << std::endl;
 }
 
 
 int main() {
-    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << Logger::endl;
-    Logger::log << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << Logger::endl;
-    Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << Logger::endl;
+    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "This is a debug message from Team A." << "aye 2" << std::endl;
+    Logger::log << Team::TEAM_2 << LogLevel::INFO << Color::GREEN << "This is an info message from Team B." << std::endl;
+    Logger::log << Team::TEAM_3 << LogLevel::ERROR << Color::RED << " RED Error message from Team C." << std::endl;
     Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE << "Error message from Team C. no endl";
     Logger::log << "cont no endl Error message from Team";
 
-    Logger::log << std::endl <<  "Warning message standard overload" << Logger::endl;
+    Logger::log << std::endl <<  "Warning message standard overload" << std::endl;
 
     samplefunction();
 

--- a/source/core/DEVELOPER_NOTES.md
+++ b/source/core/DEVELOPER_NOTES.md
@@ -42,3 +42,43 @@ only on files above it in the core.
 
 - Should Agents keep a link back to the world they're from?
 - Should Agents all have a facing?  (Or should all entities even?)
+
+
+## `EasyLogging.h`
+
+Certainly! Here are the examples provided earlier formatted in Markdown:
+
+### 1. Basic Logging:
+```cpp
+Logger::log << Team::TEAM_1 << LogLevel::DEBUG << "This is a debug message." << Logger::endl;
+Logger::log << Team::TEAM_2 << LogLevel::ERROR << "An error occurred!" << Logger::endl;
+```
+
+### 2. Logging with Colors:
+```cpp
+Logger::log << Team::TEAM_3 << LogLevel::INFO << Color::GREEN << "Success message." << Logger::endl;
+Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::RED << "Error message." << Logger::endl;
+```
+
+### 3. Logging Variables:
+```cpp
+int variable = 42;
+Logger::log << Team::TEAM_5 << LogLevel::DEBUG << "The value of variable is: " << variable << Logger::endl;
+```
+
+### 4. Logging File and Line Information:
+```cpp
+Logger::log << Team::TEAM_6 << LogLevel::INFO << LOG_RELLINE << "This log is from " << __FILE__ << " line " << __LINE__ << Logger::endl;
+```
+
+### 5. Logging Function Names:
+```cpp
+Logger::log << Team::TEAM_7 << LogLevel::DEBUG << LOG_FNC << "This log is inside the function." << Logger::endl;
+```
+
+one can also just use std::endl instead of Logger::endl they are equivalent.
+
+
+calling `Team (or) LogLevel (or) std::endl (or) Logger::endl` will reset the color team, color and log level to the default values.
+
+

--- a/source/core/DEVELOPER_NOTES.md
+++ b/source/core/DEVELOPER_NOTES.md
@@ -46,7 +46,6 @@ only on files above it in the core.
 
 ## `EasyLogging.h`
 
-Certainly! Here are the examples provided earlier formatted in Markdown:
 
 ### 1. Basic Logging:
 ```cpp

--- a/source/core/DEVELOPER_NOTES.md
+++ b/source/core/DEVELOPER_NOTES.md
@@ -82,3 +82,19 @@ one can also just use std::endl instead of Logger::endl they are equivalent.
 calling `Team (or) LogLevel (or) std::endl (or) Logger::endl` will reset the color team, color and log level to the default values.
 
 
+Current Feature set.
+
+- setting team number
+- setting log status [debug, info, warning, error]
+- setting colors of print statements.
+- Does not compile in RELEASE
+- Line number and file name
+
+
+Future Feature set.
+- logging to a file
+- adding flags for debuging in cmake.
+- making it run on a different thread/ running it Asynchronously?. Especially helpful for improving performance and responsiveness
+    - cuz of the io operation or if we want to send stuff thru the network
+- More log levels like `Fatal` or `Trace`
+- Categorization and filtering thru flags

--- a/source/core/DEVELOPER_NOTES.md
+++ b/source/core/DEVELOPER_NOTES.md
@@ -49,30 +49,30 @@ only on files above it in the core.
 
 ### 1. Basic Logging:
 ```cpp
-Logger::log << Team::TEAM_1 << LogLevel::DEBUG << "This is a debug message." << Logger::endl;
-Logger::log << Team::TEAM_2 << LogLevel::ERROR << "An error occurred!" << Logger::endl;
+Logger::Log() << Team::TEAM_1 << LogLevel::DEBUG << "This is a debug message." << std::endl;
+Logger::Log() << Team::TEAM_2 << LogLevel::ERROR << "An error occurred!" << std::endl;
 ```
 
 ### 2. Logging with Colors:
 ```cpp
-Logger::log << Team::TEAM_3 << LogLevel::INFO << Color::GREEN << "Success message." << Logger::endl;
-Logger::log << Team::TEAM_4 << LogLevel::ERROR << Color::RED << "Error message." << Logger::endl;
+Logger::Log() << Team::TEAM_3 << LogLevel::INFO << Color::GREEN << "Success message." << Logger::endl;
+Logger::Log() << Team::TEAM_4 << LogLevel::ERROR << Color::RED << "Error message." << Logger::endl;
 ```
 
 ### 3. Logging Variables:
 ```cpp
 int variable = 42;
-Logger::log << Team::TEAM_5 << LogLevel::DEBUG << "The value of variable is: " << variable << Logger::endl;
+Logger::Log() << Team::TEAM_5 << LogLevel::DEBUG << "The value of variable is: " << variable << Logger::endl;
 ```
 
 ### 4. Logging File and Line Information:
 ```cpp
-Logger::log << Team::TEAM_6 << LogLevel::INFO << LOG_RELLINE << "This log is from " << __FILE__ << " line " << __LINE__ << Logger::endl;
+Logger::Log() << Team::TEAM_6 << LogLevel::INFO << LOG_RELLINE << "This log is from " << __FILE__ << " line " << __LINE__ << Logger::endl;
 ```
 
 ### 5. Logging Function Names:
 ```cpp
-Logger::log << Team::TEAM_7 << LogLevel::DEBUG << LOG_FNC << "This log is inside the function." << Logger::endl;
+Logger::Log() << Team::TEAM_7 << LogLevel::DEBUG << LOG_FNC << "This log is inside the function." << Logger::endl;
 ```
 
 one can also just use std::endl instead of Logger::endl they are equivalent.

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -1,0 +1,129 @@
+#include <iostream>
+#include <sstream>
+#include <map>
+
+enum class LogLevel {
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR
+};
+
+enum class Team {
+    TEAM_1,
+    TEAM_2,
+    TEAM_3,
+    TEAM_4,
+    TEAM_5,
+    TEAM_6,
+    TEAM_7,
+    TEAM_8,
+    TEAM_9,
+    GENERAL,
+    NA
+};
+
+enum class Color {
+    RESET = 0,
+    BLUE = 34,
+    GREEN = 32,
+    RED = 31
+};
+
+const LogLevel LOGLEVEL = LogLevel::DEBUG;
+
+class Logger {
+public:
+    Logger& operator<<(Team team) {
+        currentTeam = team;
+        return *this;
+    }
+
+    Logger& operator<<(LogLevel logLevel) {
+        currentLogLevel = logLevel;
+        return *this;
+    }
+
+    Logger& operator<<(Color color) {
+        currentColor = color;
+        return *this;
+    }
+
+    Logger& operator<<(std::ostream& (*manipulator)(std::ostream&)) {
+        if (manipulator == endl) {
+
+            currentTeam = Team::NA;
+            currentLogLevel = LogLevel::DEBUG;
+            currentColor = Color::RESET;
+        }
+        return *this;
+    }
+
+    template <typename T>
+    Logger& operator<<(const T& value) {
+        #ifndef NDEBUG
+        if (currentLogLevel >= LOGLEVEL)
+        {
+            std::ostringstream logMessage;
+            logMessage << "\033[" << static_cast<int>(currentColor) << "m[" << teamToString(currentTeam) << "]" << logToString(currentLogLevel) << " " << value << "\033[0m";
+            std::cout << logMessage.str() << std::endl;
+        }
+        #endif
+        return *this;
+    }
+
+
+    static Logger log; // Global log instance
+    static std::ostream& endl(std::ostream& os) {
+
+        log << std::endl; // Call the custom Logger::endl to reset values
+        return os;
+    }
+
+private:
+    Team currentTeam = Team::NA;
+    LogLevel currentLogLevel = LogLevel::DEBUG;
+    Color currentColor = Color::RESET;
+
+
+    std::map<Team, std::string> teamToStringMap = {
+            {Team::TEAM_1, "Team 1"},
+            {Team::TEAM_2, "Team 2"},
+            {Team::TEAM_3, "Team 3"},
+            {Team::TEAM_4, "Team 4"},
+            {Team::TEAM_5, "Team 5"},
+            {Team::TEAM_6, "Team 6"},
+            {Team::TEAM_7, "Team 7"},
+            {Team::TEAM_8, "Team 8"},
+            {Team::TEAM_9, "Team 9"},
+            {Team::NA, "NA"},
+            {Team::GENERAL, "General"}
+    };
+
+    std::string teamToString(Team team) {
+
+        auto it = teamToStringMap.find(team);
+        if (it != teamToStringMap.end()) {
+            return it->second;
+        }
+
+        return "Unknown Team";
+
+    }
+
+    std::string logToString(LogLevel logLevel) {
+        if (logLevel == LogLevel::DEBUG) {
+            return "(DEBUG)";
+        } else if (logLevel == LogLevel::INFO) {
+            return "(INFO)";
+        } else if (logLevel == LogLevel::WARNING) {
+            return "(WARNING)";
+        } else if (logLevel == LogLevel::ERROR) {
+            return "(ERROR)";
+        } else {
+            return "";
+        }
+    }
+};
+
+Logger Logger::log;

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -58,7 +58,7 @@ const LogLevel LOGLEVEL = LogLevel::DEBUG;
 
 /// Not a fan of this practice
 /// But would prefer not to use parenthesis
-#define log Log()
+
 
 /**
  * @brief Logger class with colors and team names

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -6,7 +6,8 @@ enum class LogLevel {
     DEBUG,
     INFO,
     WARNING,
-    ERROR
+    ERROR,
+    NA
 };
 
 enum class Team {
@@ -55,6 +56,7 @@ public:
             currentTeam = Team::NA;
             currentLogLevel = LogLevel::DEBUG;
             currentColor = Color::RESET;
+
         }
         return *this;
     }
@@ -65,7 +67,7 @@ public:
         if (currentLogLevel >= LOGLEVEL)
         {
             std::ostringstream logMessage;
-            logMessage << "\033[" << static_cast<int>(currentColor) << "m[" << teamToString(currentTeam) << "]" << logToString(currentLogLevel) << " " << value << "\033[0m";
+            logMessage << "\033[" << static_cast<int>(currentColor) << "m" << teamToString(currentTeam) << logToString(currentLogLevel)  << value << "\033[0m";
             std::cout << logMessage.str() << std::endl;
         }
         #endif
@@ -96,7 +98,6 @@ private:
             {Team::TEAM_7, "Team 7"},
             {Team::TEAM_8, "Team 8"},
             {Team::TEAM_9, "Team 9"},
-            {Team::NA, "NA"},
             {Team::GENERAL, "General"}
     };
 
@@ -104,22 +105,22 @@ private:
 
         auto it = teamToStringMap.find(team);
         if (it != teamToStringMap.end()) {
-            return it->second;
+            return "[" + it->second + "]";
         }
 
-        return "Unknown Team";
+        return "";
 
     }
 
     std::string logToString(LogLevel logLevel) {
         if (logLevel == LogLevel::DEBUG) {
-            return "(DEBUG)";
+            return "(DEBUG) " ;
         } else if (logLevel == LogLevel::INFO) {
-            return "(INFO)";
+            return "(INFO) ";
         } else if (logLevel == LogLevel::WARNING) {
-            return "(WARNING)";
+            return "(WARNING) ";
         } else if (logLevel == LogLevel::ERROR) {
-            return "(ERROR)";
+            return "(ERROR) ";
         } else {
             return "";
         }

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -3,9 +3,6 @@
 #include <map>
 #include <fstream>
 
-#include <cstdlib>
-
-
 namespace clogged{
 
 /**
@@ -169,25 +166,14 @@ namespace clogged{
             //TODO: Define when to log by loglevel comparison. Goal is to send it in as a flag in the CMakeLists.txt
             if (currentLogLevel >= LOGLEVEL) {
 
-
-                const char* term = std::getenv("TERM");
+                // added additional flag in case one wants to compile without colors (or) if the terminal does not support colors
+#ifndef D_ANSI_COLOR_CODES
+                std::string colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
+                std::string colorEnd = "\033[0m";
+#else
                 std::string colorStart = "";
                 std::string colorEnd = "";
-
-                if (term != nullptr) {
-                    colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
-                    colorEnd = "\033[0m";
-                }
-
-//
-//                // added additional flag in case one wants to compile without colors (or) if the terminal does not support colors
-//#ifndef D_ANSI_COLOR_CODES
-//                std::string colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
-//                std::string colorEnd = "\033[0m";
-//#else
-//                std::string colorStart = "";
-//                std::string colorEnd = "";
-//#endif
+#endif
                 std::ostringstream logMessage;
                 logMessage << colorStart;
                 if (!metaPrinted) {

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <sstream>
 #include <map>
-
+#include <fstream>
 
 /**
  * @brief Log levels for logging
@@ -54,6 +54,19 @@ const LogLevel LOGLEVEL = LogLevel::DEBUG;
 /// @brief Ensure that we only log when NDEBUG flg is not set
 #ifndef NDEBUG
 
+#define LOGLINE \
+        "File: " << __FILE__ <<  "::->::Line(" << __LINE__ << ")"
+
+#define RELATIVE_PATH(file) \
+    (std::string(file).find_last_of("/\\") != std::string::npos \
+        ? std::string(file).substr(std::string(file).find_last_of("/\\") + 1) \
+        : std::string(file))
+
+#define LOG_RELLINE \
+        "File: " << RELATIVE_PATH(__FILE__) << "::->::Line(" << __LINE__ << ")"
+
+#define LOG_FNC \
+        "Function: " << __func__ << " "
 /**
  * @brief Logger class with colors and team names
  * @author @amantham20 @chatGPT
@@ -89,6 +102,8 @@ public:
         return *this;
     }
 
+
+
     /**
      * @brief colors of the log
      * 
@@ -107,6 +122,18 @@ public:
      * @return Logger& 
      */
     Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
+
+        typedef std::ostream& (*EndlManipulator)(std::ostream&);
+
+        // Compare the function pointers
+        if (manipulator == static_cast<EndlManipulator>(std::endl)) {
+            // Handle std::endl here
+            currentTeam = Team::NA;
+            currentLogLevel = LogLevel::DEBUG;
+            currentColor = Color::RESET;
+            std::cout << std::endl;
+        }
+
         if (manipulator == endl) {
 
             currentTeam = Team::NA;
@@ -187,6 +214,8 @@ private:
 
     bool metaPrinted = false;
 
+
+
     /**
      * @brief Map to convert Team enum to string
      * 
@@ -242,10 +271,18 @@ private:
     }
 };
 
+
+
 /// @brief Global log instance
 Logger Logger::log;
 
 #else
+
+#define LOGLINE ""
+#define LOG_RELLINE ""
+#define LOG_FNC ""
+
+
 class Logger {
 public:
     template <typename T>

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -3,6 +3,9 @@
 #include <map>
 #include <fstream>
 
+#include <cstdlib>
+
+
 namespace clogged{
 
 /**
@@ -166,14 +169,25 @@ namespace clogged{
             //TODO: Define when to log by loglevel comparison. Goal is to send it in as a flag in the CMakeLists.txt
             if (currentLogLevel >= LOGLEVEL) {
 
-                // added additional flag in case one wants to compile without colors (or) if the terminal does not support colors
-#ifndef D_ANSI_COLOR_CODES
-                std::string colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
-                std::string colorEnd = "\033[0m";
-#else
+
+                const char* term = std::getenv("TERM");
                 std::string colorStart = "";
                 std::string colorEnd = "";
-#endif
+
+                if (term != nullptr) {
+                    colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
+                    colorEnd = "\033[0m";
+                }
+
+//
+//                // added additional flag in case one wants to compile without colors (or) if the terminal does not support colors
+//#ifndef D_ANSI_COLOR_CODES
+//                std::string colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
+//                std::string colorEnd = "\033[0m";
+//#else
+//                std::string colorStart = "";
+//                std::string colorEnd = "";
+//#endif
                 std::ostringstream logMessage;
                 logMessage << colorStart;
                 if (!metaPrinted) {

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -2,6 +2,11 @@
 #include <sstream>
 #include <map>
 
+
+/**
+ * @brief Log levels for logging
+ * 
+ */
 enum class LogLevel {
     DEBUG,
     INFO,
@@ -10,6 +15,10 @@ enum class LogLevel {
     NA
 };
 
+/**
+ * @brief Teams Names for logging
+ * 
+ */
 enum class Team {
     TEAM_1,
     TEAM_2,
@@ -24,6 +33,10 @@ enum class Team {
     NA
 };
 
+/**
+ * @brief Colors for logging
+ * 
+ */
 enum class Color {
     RESET = 0,
     BLUE = 34,
@@ -31,36 +44,84 @@ enum class Color {
     RED = 31
 };
 
+/**
+ * @brief Level of logging
+ * @TODO: Change this to be a flag in the CMakeLists.txt
+ */
 const LogLevel LOGLEVEL = LogLevel::DEBUG;
 
+
+/**
+ * @brief Logger class with colors and team names
+ * @author @amantham20 @chatGPT
+ * 
+ * @details I was about to name this clogged.
+ * @details This is a custom logger class that can be used to log messages to the console.
+ */
 class Logger {
 public:
+
+    /**
+     * @brief Sets the Team name for the current log
+     * 
+     * @param team name of the team
+     * @return Logger& 
+     */
     Logger& operator<<(Team team) {
         currentTeam = team;
+        // std::cout << endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
         return *this;
     }
 
+    /**
+     * @brief sets the log level for the current log
+     * 
+     * @param logLevel Level/Type of the log
+     * @return Logger& 
+     */
     Logger& operator<<(LogLevel logLevel) {
         currentLogLevel = logLevel;
         return *this;
     }
 
+    /**
+     * @brief colors of the log
+     * 
+     * @param color 
+     * @return Logger& 
+     */
     Logger& operator<<(Color color) {
         currentColor = color;
         return *this;
     }
 
+    /**
+     * @brief Manipulator for endl so that we can reset the values when a team is done logging
+     * 
+     * @param manipulator 
+     * @return Logger& 
+     */
     Logger& operator<<(std::ostream& (*manipulator)(std::ostream&)) {
         if (manipulator == endl) {
 
             currentTeam = Team::NA;
             currentLogLevel = LogLevel::DEBUG;
             currentColor = Color::RESET;
-
+            // std::cout << std::endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
         }
         return *this;
     }
 
+    /**
+     * @brief Aye I used a template.
+     * @brief Function to log the value
+     * 
+     * @tparam T 
+     * @param value 
+     * @return Logger& 
+     * 
+     * @TODO: Might have to change this so that we only break a team log when a new team is set. aka ensure that  logger << Team::TEAM_1 << "Hello" << "World" << endl; works in one line with one team print
+     */
     template <typename T>
     Logger& operator<<(const T& value) {
         #ifndef NDEBUG
@@ -68,14 +129,23 @@ public:
         {
             std::ostringstream logMessage;
             logMessage << "\033[" << static_cast<int>(currentColor) << "m" << teamToString(currentTeam) << logToString(currentLogLevel)  << value << "\033[0m";
-            std::cout << logMessage.str() << std::endl;
+            std::cout << logMessage.str();
+                            //            << std::endl;  //TODO: Might have to make enable this so that we can have same line logging when endl is not used
         }
         #endif
         return *this;
     }
 
 
-    static Logger log; // Global log instance
+
+    static Logger log; /// Global log instance //TODO: Check if poluting the global namespace is a good idea??
+
+    /**
+     * @brief Custom endl to reset the values
+     * 
+     * @param os 
+     * @return std::ostream& 
+     */
     static std::ostream& endl(std::ostream& os) {
 
         log << std::endl; // Call the custom Logger::endl to reset values
@@ -83,11 +153,19 @@ public:
     }
 
 private:
+    /// @brief Current team for that is going to log
     Team currentTeam = Team::NA;
+
+    /// @brief Current log level for the log
     LogLevel currentLogLevel = LogLevel::DEBUG;
+
+    /// @brief Current color for the log
     Color currentColor = Color::RESET;
 
-
+    /**
+     * @brief Map to convert Team enum to string
+     * 
+     */
     std::map<Team, std::string> teamToStringMap = {
             {Team::TEAM_1, "Team 1"},
             {Team::TEAM_2, "Team 2"},
@@ -101,6 +179,12 @@ private:
             {Team::GENERAL, "General"}
     };
 
+    /**
+     * @brief Converts Team enum to string
+     * 
+     * @param team 
+     * @return std::string 
+     */
     std::string teamToString(Team team) {
 
         auto it = teamToStringMap.find(team);
@@ -112,6 +196,12 @@ private:
 
     }
 
+    /**
+     * @brief Converts LogLevel enum to string
+     * 
+     * @param logLevel 
+     * @return std::string 
+     */
     std::string logToString(LogLevel logLevel) {
         if (logLevel == LogLevel::DEBUG) {
             return "(DEBUG) " ;
@@ -127,4 +217,5 @@ private:
     }
 };
 
+/// @brief Global log instance
 Logger Logger::log;

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -56,6 +56,10 @@ const LogLevel LOGLEVEL = LogLevel::DEBUG;
 
 #define LOG_FNC "Function: " << __func__ << " "
 
+/// Not a fan of this practice
+/// But would prefer not to use parenthesis
+#define log Log()
+
 /**
  * @brief Logger class with colors and team names
  * @author @amantham20 @chatGPT
@@ -173,10 +177,37 @@ class Logger {
     return *this;
   }
 
-  //  static Logger log; /// Global log instance //TODO: Check if poluting the
-  /// global namespace is a good idea??
 
-  static Logger log;
+    /**
+     * Only instance of the logger once
+     * Changes requested from Dr.@ofria
+     *
+     * @authors @mercere99
+     * @return
+     */
+    static Logger& Log() {
+      static Logger instance; // Guaranteed to be initialized only once.
+      return instance;
+    }
+
+    /**
+     * Only instance of the logger once
+     * Changes requested from Dr.@ofria
+     *
+     * @authors @mercere99
+     * @return
+     */
+    template <typename T, typename... EXTRA_Ts>
+    static Logger & Log(T && arg1, EXTRA_Ts &&... extra_args) {
+      Log() << std::forward<T>(arg1);  // Log the first argument.
+      if constexpr (sizeof...(EXTRA_Ts) == 0) {  // No arguments left.
+        return Log() << Logger::endl;  // Trigger a flush.
+      } else {
+        return Log(std::forward<EXTRA_Ts>(extra_args)...);  // Log remaining arguments.
+      }
+    }
+
+
   /**
    * @brief Custom endl to reset the values
    *
@@ -184,7 +215,7 @@ class Logger {
    * @return std::ostream&
    */
   static std::ostream &endl(std::ostream &os) {
-    log << std::endl;  // Call the custom Logger::endl to reset values
+    Log() << std::endl;  // Call the custom Logger::endl to reset values
     return os;
   }
 
@@ -247,8 +278,7 @@ class Logger {
   }
 };
 
-/// @brief Global log instance
-Logger Logger::log;
+
 
 #else
 

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -72,6 +72,7 @@ public:
      */
     Logger &operator<<(Team team) {
         currentTeam = team;
+        metaPrinted = false;
 //         std::cout << endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
         return *this;
     }
@@ -84,6 +85,7 @@ public:
      */
     Logger &operator<<(LogLevel logLevel) {
         currentLogLevel = logLevel;
+        metaPrinted = false;
         return *this;
     }
 
@@ -110,8 +112,10 @@ public:
             currentTeam = Team::NA;
             currentLogLevel = LogLevel::DEBUG;
             currentColor = Color::RESET;
+
             std::cout
                     << std::endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
+            metaPrinted = false;
         }
         return *this;
     }
@@ -142,8 +146,13 @@ public:
             std::string colorEnd = "";
             #endif
             std::ostringstream logMessage;
-            logMessage << colorStart << teamToString(currentTeam)
-                       << logToString(currentLogLevel) << value << colorEnd;
+            logMessage << colorStart;
+            if (!metaPrinted) {
+                logMessage << teamToString(currentTeam) << logToString(currentLogLevel);
+                metaPrinted = true;
+            }
+
+            logMessage << value << colorEnd;
             std::cout
                     << logMessage.str(); // << std::endl;  //TODO: Might have to make enable this so that we can have same line logging when endl is not used
         }
@@ -175,6 +184,8 @@ private:
 
     /// @brief Current color for the log
     Color currentColor = Color::RESET;
+
+    bool metaPrinted = false;
 
     /**
      * @brief Map to convert Team enum to string

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -46,12 +46,12 @@ const LogLevel LOGLEVEL = LogLevel::DEBUG;
 
 #define LOGLINE "File: " << __FILE__ << "::->::Line(" << __LINE__ << ")"
 
-#define RELATIVE_PATH(file)                                                    \
-  (std::string(file).find_last_of("/\\") != std::string::npos                  \
-       ? std::string(file).substr(std::string(file).find_last_of("/\\") + 1)   \
+#define RELATIVE_PATH(file)                                                  \
+  (std::string(file).find_last_of("/\\") != std::string::npos                \
+       ? std::string(file).substr(std::string(file).find_last_of("/\\") + 1) \
        : std::string(file))
 
-#define LOG_RELLINE                                                            \
+#define LOG_RELLINE \
   "File: " << RELATIVE_PATH(__FILE__) << "::->::Line(" << __LINE__ << ")"
 
 #define LOG_FNC "Function: " << __func__ << " "
@@ -65,7 +65,7 @@ const LogLevel LOGLEVEL = LogLevel::DEBUG;
  * the console.
  */
 class Logger {
-public:
+ public:
   /**
    * @brief Sets the Team name for the current log
    *
@@ -111,28 +111,21 @@ public:
    * @return Logger&
    */
   Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
-
     typedef std::ostream &(*EndlManipulator)(std::ostream &);
 
     // Compare the function pointers
-    if (manipulator == static_cast<EndlManipulator>(std::endl)) {
+    if (manipulator == static_cast<EndlManipulator>(std::endl) ||
+        manipulator == endl) {
       // Handle std::endl here
       currentTeam = Team::NA;
       currentLogLevel = LogLevel::DEBUG;
       currentColor = Color::RESET;
+
       std::cout << std::endl;
-    }
 
-    if (manipulator == endl) {
-
-      currentTeam = Team::NA;
-      currentLogLevel = LogLevel::DEBUG;
-      currentColor = Color::RESET;
-
-      std::cout << std::endl; // TODO: Might have to enable this so that we can
-                              // have same line logging when endl is not used
       metaPrinted = false;
     }
+
     return *this;
   }
 
@@ -148,12 +141,11 @@ public:
    * new team is set. aka ensure that  logger << Team::TEAM_1 << "Hello" <<
    * "World" << endl; works in one line with one team print
    */
-  template <typename T> Logger &operator<<(const T &value) {
-
+  template <typename T>
+  Logger &operator<<(const T &value) {
     // TODO: Define when to log by loglevel comparison. Goal is to send it in as
     // a flag in the CMakeLists.txt
     if (currentLogLevel >= LOGLEVEL) {
-
       // added additional flag in case one wants to compile without colors (or)
       // if the terminal does not support colors
 #ifndef D_ANSI_COLOR_CODES
@@ -172,16 +164,22 @@ public:
       }
 
       logMessage << value << colorEnd;
-      std::cout << logMessage.str(); // << std::endl;  //TODO: Might have to
-                                     // make enable this so that we can have
-                                     // same line logging when endl is not used
+      std::cout << logMessage.str();  // << std::endl;  //TODO: Might have to
+                                      // make enable this so that we can have
+                                      // same line logging when endl is not used
     }
 
     return *this;
   }
 
-  static Logger log; /// Global log instance //TODO: Check if poluting the
-                     /// global namespace is a good idea??
+  //  static Logger log; /// Global log instance //TODO: Check if poluting the
+  /// global namespace is a good idea??
+
+  static Logger &Log() {
+    static Logger log;  // Creates this instance of log only when called the
+                        // first time, but always uses same one.
+    return log;         // Returns a consistent instance of log.
+  }
 
   /**
    * @brief Custom endl to reset the values
@@ -190,12 +188,11 @@ public:
    * @return std::ostream&
    */
   static std::ostream &endl(std::ostream &os) {
-
-    log << std::endl; // Call the custom Logger::endl to reset values
+    log << std::endl;  // Call the custom Logger::endl to reset values
     return os;
   }
 
-private:
+ private:
   /// @brief Current team for that is going to log
   Team currentTeam = Team::NA;
 
@@ -225,7 +222,6 @@ private:
    * @return std::string
    */
   std::string teamToString(Team team) {
-
     auto it = teamToStringMap.find(team);
     if (it != teamToStringMap.end()) {
       return "[" + it->second + "]";
@@ -265,8 +261,11 @@ Logger Logger::log;
 #define LOG_FNC ""
 
 class Logger {
-public:
-  template <typename T> Logger &operator<<(const T &value) { return *this; }
+ public:
+  template <typename T>
+  Logger &operator<<(const T &value) {
+    return *this;
+  }
 
   Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
     return *this;
@@ -280,4 +279,4 @@ public:
 Logger Logger::log;
 #endif
 
-} // namespace clogged
+}  // namespace clogged

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -286,6 +286,8 @@ class Logger {
 #define LOG_RELLINE ""
 #define LOG_FNC ""
 
+#define log Log()
+
 class Logger {
  public:
   template <typename T>
@@ -299,10 +301,14 @@ class Logger {
 
   static std::ostream &endl(std::ostream &os) { return os; }
 
-  static Logger log;
+  static Logger& Log() {
+    static Logger instance; // Guaranteed to be initialized only once.
+    return instance;
+  }
+
 };
 
-Logger Logger::log;
+//Logger Logger::log;
 #endif
 
 }  // namespace clogged

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -124,6 +124,8 @@ public:
      */
     template <typename T>
     Logger& operator<<(const T& value) {
+
+        /// @brief Ensure that we only log when NDEBUG flg is not set
         #ifndef NDEBUG
         if (currentLogLevel >= LOGLEVEL)
         {

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -103,6 +103,7 @@ class Logger {
     return *this;
   }
 
+
   /**
    * @brief Manipulator for endl so that we can reset the values when a team is
    * done logging
@@ -175,12 +176,7 @@ class Logger {
   //  static Logger log; /// Global log instance //TODO: Check if poluting the
   /// global namespace is a good idea??
 
-  static Logger &Log() {
-    static Logger log;  // Creates this instance of log only when called the
-                        // first time, but always uses same one.
-    return log;         // Returns a consistent instance of log.
-  }
-
+  static Logger log;
   /**
    * @brief Custom endl to reset the values
    *

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -1,280 +1,262 @@
-#include <iostream>
-#include <sstream>
-#include <map>
 #include <fstream>
+#include <iostream>
+#include <map>
+#include <sstream>
 
-namespace clogged{
+namespace clogged {
 
 /**
  * @brief Log levels for logging
- * 
+ *
  */
-    enum class LogLevel {
-        DEBUG,
-        INFO,
-        WARNING,
-        ERROR,
-        NA
-    };
+enum class LogLevel { DEBUG, INFO, WARNING, ERROR, NA };
 
 /**
  * @brief Teams Names for logging
- * 
+ *
  */
-    enum class Team {
-        TEAM_1,
-        TEAM_2,
-        TEAM_3,
-        TEAM_4,
-        TEAM_5,
-        TEAM_6,
-        TEAM_7,
-        TEAM_8,
-        TEAM_9,
-        GENERAL,
-        NA
-    };
+enum class Team {
+  TEAM_1,
+  TEAM_2,
+  TEAM_3,
+  TEAM_4,
+  TEAM_5,
+  TEAM_6,
+  TEAM_7,
+  TEAM_8,
+  TEAM_9,
+  GENERAL,
+  NA
+};
 
 /**
  * @brief Colors for logging
- * 
+ *
  */
-    enum class Color {
-        RESET = 0,
-        BLUE = 34,
-        GREEN = 32,
-        RED = 31
-    };
+enum class Color { RESET = 0, BLUE = 34, GREEN = 32, RED = 31 };
 
 /**
  * @brief Level of logging
  * @TODO: Change this to be a flag in the CMakeLists.txt
  */
-    const LogLevel LOGLEVEL = LogLevel::DEBUG;
-
+const LogLevel LOGLEVEL = LogLevel::DEBUG;
 
 /// @brief Ensure that we only log when NDEBUG flg is not set
 #ifndef NDEBUG
 
-#define LOGLINE \
-        "File: " << __FILE__ <<  "::->::Line(" << __LINE__ << ")"
+#define LOGLINE "File: " << __FILE__ << "::->::Line(" << __LINE__ << ")"
 
-#define RELATIVE_PATH(file) \
-    (std::string(file).find_last_of("/\\") != std::string::npos \
-        ? std::string(file).substr(std::string(file).find_last_of("/\\") + 1) \
-        : std::string(file))
+#define RELATIVE_PATH(file)                                                    \
+  (std::string(file).find_last_of("/\\") != std::string::npos                  \
+       ? std::string(file).substr(std::string(file).find_last_of("/\\") + 1)   \
+       : std::string(file))
 
-#define LOG_RELLINE \
-        "File: " << RELATIVE_PATH(__FILE__) << "::->::Line(" << __LINE__ << ")"
+#define LOG_RELLINE                                                            \
+  "File: " << RELATIVE_PATH(__FILE__) << "::->::Line(" << __LINE__ << ")"
 
-#define LOG_FNC \
-        "Function: " << __func__ << " "
+#define LOG_FNC "Function: " << __func__ << " "
 
 /**
  * @brief Logger class with colors and team names
  * @author @amantham20 @chatGPT
- * 
+ *
  * @details I was about to name this clogged.
- * @details This is a custom logger class that can be used to log messages to the console.
+ * @details This is a custom logger class that can be used to log messages to
+ * the console.
  */
-    class Logger {
-    public:
+class Logger {
+public:
+  /**
+   * @brief Sets the Team name for the current log
+   *
+   * @param team name of the team
+   * @return Logger&
+   */
+  Logger &operator<<(Team team) {
+    currentTeam = team;
+    metaPrinted = false;
+    //         std::cout << endl; //TODO: Might have to enable this so that we
+    //         can have same line logging when endl is not used
+    return *this;
+  }
 
-        /**
-         * @brief Sets the Team name for the current log
-         *
-         * @param team name of the team
-         * @return Logger&
-         */
-        Logger &operator<<(Team team) {
-            currentTeam = team;
-            metaPrinted = false;
-//         std::cout << endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
-            return *this;
-        }
+  /**
+   * @brief sets the log level for the current log
+   *
+   * @param logLevel Level/Type of the log
+   * @return Logger&
+   */
+  Logger &operator<<(LogLevel logLevel) {
+    currentLogLevel = logLevel;
+    metaPrinted = false;
+    return *this;
+  }
 
-        /**
-         * @brief sets the log level for the current log
-         *
-         * @param logLevel Level/Type of the log
-         * @return Logger&
-         */
-        Logger &operator<<(LogLevel logLevel) {
-            currentLogLevel = logLevel;
-            metaPrinted = false;
-            return *this;
-        }
+  /**
+   * @brief colors of the log
+   *
+   * @param color
+   * @return Logger&
+   */
+  Logger &operator<<(Color color) {
+    currentColor = color;
+    return *this;
+  }
 
+  /**
+   * @brief Manipulator for endl so that we can reset the values when a team is
+   * done logging
+   *
+   * @param manipulator
+   * @return Logger&
+   */
+  Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
 
-        /**
-         * @brief colors of the log
-         *
-         * @param color
-         * @return Logger&
-         */
-        Logger &operator<<(Color color) {
-            currentColor = color;
-            return *this;
-        }
+    typedef std::ostream &(*EndlManipulator)(std::ostream &);
 
-        /**
-         * @brief Manipulator for endl so that we can reset the values when a team is done logging
-         *
-         * @param manipulator
-         * @return Logger&
-         */
-        Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
+    // Compare the function pointers
+    if (manipulator == static_cast<EndlManipulator>(std::endl)) {
+      // Handle std::endl here
+      currentTeam = Team::NA;
+      currentLogLevel = LogLevel::DEBUG;
+      currentColor = Color::RESET;
+      std::cout << std::endl;
+    }
 
-            typedef std::ostream &(*EndlManipulator)(std::ostream &);
+    if (manipulator == endl) {
 
-            // Compare the function pointers
-            if (manipulator == static_cast<EndlManipulator>(std::endl)) {
-                // Handle std::endl here
-                currentTeam = Team::NA;
-                currentLogLevel = LogLevel::DEBUG;
-                currentColor = Color::RESET;
-                std::cout << std::endl;
-            }
+      currentTeam = Team::NA;
+      currentLogLevel = LogLevel::DEBUG;
+      currentColor = Color::RESET;
 
-            if (manipulator == endl) {
+      std::cout << std::endl; // TODO: Might have to enable this so that we can
+                              // have same line logging when endl is not used
+      metaPrinted = false;
+    }
+    return *this;
+  }
 
-                currentTeam = Team::NA;
-                currentLogLevel = LogLevel::DEBUG;
-                currentColor = Color::RESET;
+  /**
+   * @brief Aye I used a template.
+   * @brief Function to log the value
+   *
+   * @tparam T
+   * @param value
+   * @return Logger&
+   *
+   * @TODO: Might have to change this so that we only break a team log when a
+   * new team is set. aka ensure that  logger << Team::TEAM_1 << "Hello" <<
+   * "World" << endl; works in one line with one team print
+   */
+  template <typename T> Logger &operator<<(const T &value) {
 
-                std::cout
-                        << std::endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
-                metaPrinted = false;
-            }
-            return *this;
-        }
+    // TODO: Define when to log by loglevel comparison. Goal is to send it in as
+    // a flag in the CMakeLists.txt
+    if (currentLogLevel >= LOGLEVEL) {
 
-        /**
-         * @brief Aye I used a template.
-         * @brief Function to log the value
-         *
-         * @tparam T
-         * @param value
-         * @return Logger&
-         *
-         * @TODO: Might have to change this so that we only break a team log when a new team is set. aka ensure that  logger << Team::TEAM_1 << "Hello" << "World" << endl; works in one line with one team print
-         */
-        template<typename T>
-        Logger &operator<<(const T &value) {
-
-
-            //TODO: Define when to log by loglevel comparison. Goal is to send it in as a flag in the CMakeLists.txt
-            if (currentLogLevel >= LOGLEVEL) {
-
-                // added additional flag in case one wants to compile without colors (or) if the terminal does not support colors
+      // added additional flag in case one wants to compile without colors (or)
+      // if the terminal does not support colors
 #ifndef D_ANSI_COLOR_CODES
-                std::string colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
-                std::string colorEnd = "\033[0m";
+      std::string colorStart =
+          "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
+      std::string colorEnd = "\033[0m";
 #else
-                std::string colorStart = "";
-                std::string colorEnd = "";
+      std::string colorStart = "";
+      std::string colorEnd = "";
 #endif
-                std::ostringstream logMessage;
-                logMessage << colorStart;
-                if (!metaPrinted) {
-                    logMessage << teamToString(currentTeam) << logToString(currentLogLevel);
-                    metaPrinted = true;
-                }
+      std::ostringstream logMessage;
+      logMessage << colorStart;
+      if (!metaPrinted) {
+        logMessage << teamToString(currentTeam) << logToString(currentLogLevel);
+        metaPrinted = true;
+      }
 
-                logMessage << value << colorEnd;
-                std::cout
-                        << logMessage.str(); // << std::endl;  //TODO: Might have to make enable this so that we can have same line logging when endl is not used
-            }
+      logMessage << value << colorEnd;
+      std::cout << logMessage.str(); // << std::endl;  //TODO: Might have to
+                                     // make enable this so that we can have
+                                     // same line logging when endl is not used
+    }
 
-            return *this;
-        }
+    return *this;
+  }
 
+  static Logger log; /// Global log instance //TODO: Check if poluting the
+                     /// global namespace is a good idea??
 
-        static Logger log; /// Global log instance //TODO: Check if poluting the global namespace is a good idea??
+  /**
+   * @brief Custom endl to reset the values
+   *
+   * @param os
+   * @return std::ostream&
+   */
+  static std::ostream &endl(std::ostream &os) {
 
-        /**
-         * @brief Custom endl to reset the values
-         *
-         * @param os
-         * @return std::ostream&
-         */
-        static std::ostream &endl(std::ostream &os) {
+    log << std::endl; // Call the custom Logger::endl to reset values
+    return os;
+  }
 
-            log << std::endl; // Call the custom Logger::endl to reset values
-            return os;
-        }
+private:
+  /// @brief Current team for that is going to log
+  Team currentTeam = Team::NA;
 
-    private:
-        /// @brief Current team for that is going to log
-        Team currentTeam = Team::NA;
+  /// @brief Current log level for the log
+  LogLevel currentLogLevel = LogLevel::DEBUG;
 
-        /// @brief Current log level for the log
-        LogLevel currentLogLevel = LogLevel::DEBUG;
+  /// @brief Current color for the log
+  Color currentColor = Color::RESET;
 
-        /// @brief Current color for the log
-        Color currentColor = Color::RESET;
+  bool metaPrinted = false;
 
-        bool metaPrinted = false;
+  /**
+   * @brief Map to convert Team enum to string
+   *
+   */
+  std::map<Team, std::string> teamToStringMap = {
+      {Team::TEAM_1, "Team 1"}, {Team::TEAM_2, "Team 2"},
+      {Team::TEAM_3, "Team 3"}, {Team::TEAM_4, "Team 4"},
+      {Team::TEAM_5, "Team 5"}, {Team::TEAM_6, "Team 6"},
+      {Team::TEAM_7, "Team 7"}, {Team::TEAM_8, "Team 8"},
+      {Team::TEAM_9, "Team 9"}, {Team::GENERAL, "General"}};
 
+  /**
+   * @brief Converts Team enum to string
+   *
+   * @param team
+   * @return std::string
+   */
+  std::string teamToString(Team team) {
 
-        /**
-         * @brief Map to convert Team enum to string
-         *
-         */
-        std::map<Team, std::string> teamToStringMap = {
-                {Team::TEAM_1,  "Team 1"},
-                {Team::TEAM_2,  "Team 2"},
-                {Team::TEAM_3,  "Team 3"},
-                {Team::TEAM_4,  "Team 4"},
-                {Team::TEAM_5,  "Team 5"},
-                {Team::TEAM_6,  "Team 6"},
-                {Team::TEAM_7,  "Team 7"},
-                {Team::TEAM_8,  "Team 8"},
-                {Team::TEAM_9,  "Team 9"},
-                {Team::GENERAL, "General"}
-        };
+    auto it = teamToStringMap.find(team);
+    if (it != teamToStringMap.end()) {
+      return "[" + it->second + "]";
+    }
 
-        /**
-         * @brief Converts Team enum to string
-         *
-         * @param team
-         * @return std::string
-         */
-        std::string teamToString(Team team) {
+    return "";
+  }
 
-            auto it = teamToStringMap.find(team);
-            if (it != teamToStringMap.end()) {
-                return "[" + it->second + "]";
-            }
-
-            return "";
-
-        }
-
-        /**
-         * @brief Converts LogLevel enum to string
-         *
-         * @param logLevel
-         * @return std::string
-         */
-        std::string logToString(LogLevel logLevel) {
-            if (logLevel == LogLevel::DEBUG) {
-                return "(DEBUG) ";
-            } else if (logLevel == LogLevel::INFO) {
-                return "(INFO) ";
-            } else if (logLevel == LogLevel::WARNING) {
-                return "(WARNING) ";
-            } else if (logLevel == LogLevel::ERROR) {
-                return "(ERROR) ";
-            } else {
-                return "";
-            }
-        }
-    };
-
+  /**
+   * @brief Converts LogLevel enum to string
+   *
+   * @param logLevel
+   * @return std::string
+   */
+  std::string logToString(LogLevel logLevel) {
+    if (logLevel == LogLevel::DEBUG) {
+      return "(DEBUG) ";
+    } else if (logLevel == LogLevel::INFO) {
+      return "(INFO) ";
+    } else if (logLevel == LogLevel::WARNING) {
+      return "(WARNING) ";
+    } else if (logLevel == LogLevel::ERROR) {
+      return "(ERROR) ";
+    } else {
+      return "";
+    }
+  }
+};
 
 /// @brief Global log instance
-    Logger Logger::log;
+Logger Logger::log;
 
 #else
 
@@ -282,26 +264,20 @@ namespace clogged{
 #define LOG_RELLINE ""
 #define LOG_FNC ""
 
+class Logger {
+public:
+  template <typename T> Logger &operator<<(const T &value) { return *this; }
 
-    class Logger {
-    public:
-        template <typename T>
-        Logger& operator<<(const T& value) {
-            return *this;
-        }
+  Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
+    return *this;
+  }
 
-        Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
-            return *this;
-        }
+  static std::ostream &endl(std::ostream &os) { return os; }
 
-        static std::ostream &endl(std::ostream &os) {
-            return os;
-        }
+  static Logger log;
+};
 
-        static Logger log;
-    };
-
-    Logger Logger::log;
+Logger Logger::log;
 #endif
 
-}  // namespace
+} // namespace clogged

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -69,7 +69,7 @@ public:
      */
     Logger& operator<<(Team team) {
         currentTeam = team;
-        // std::cout << endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
+//         std::cout << endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
         return *this;
     }
 
@@ -107,7 +107,7 @@ public:
             currentTeam = Team::NA;
             currentLogLevel = LogLevel::DEBUG;
             currentColor = Color::RESET;
-            // std::cout << std::endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
+             std::cout << std::endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
         }
         return *this;
     }
@@ -131,8 +131,7 @@ public:
         {
             std::ostringstream logMessage;
             logMessage << "\033[" << static_cast<int>(currentColor) << "m" << teamToString(currentTeam) << logToString(currentLogLevel)  << value << "\033[0m";
-            std::cout << logMessage.str();
-                            //            << std::endl;  //TODO: Might have to make enable this so that we can have same line logging when endl is not used
+            std::cout << logMessage.str(); // << std::endl;  //TODO: Might have to make enable this so that we can have same line logging when endl is not used
         }
         #endif
         return *this;

--- a/source/core/EasyLogging.hpp
+++ b/source/core/EasyLogging.hpp
@@ -3,52 +3,54 @@
 #include <map>
 #include <fstream>
 
+namespace clogged{
+
 /**
  * @brief Log levels for logging
  * 
  */
-enum class LogLevel {
-    DEBUG,
-    INFO,
-    WARNING,
-    ERROR,
-    NA
-};
+    enum class LogLevel {
+        DEBUG,
+        INFO,
+        WARNING,
+        ERROR,
+        NA
+    };
 
 /**
  * @brief Teams Names for logging
  * 
  */
-enum class Team {
-    TEAM_1,
-    TEAM_2,
-    TEAM_3,
-    TEAM_4,
-    TEAM_5,
-    TEAM_6,
-    TEAM_7,
-    TEAM_8,
-    TEAM_9,
-    GENERAL,
-    NA
-};
+    enum class Team {
+        TEAM_1,
+        TEAM_2,
+        TEAM_3,
+        TEAM_4,
+        TEAM_5,
+        TEAM_6,
+        TEAM_7,
+        TEAM_8,
+        TEAM_9,
+        GENERAL,
+        NA
+    };
 
 /**
  * @brief Colors for logging
  * 
  */
-enum class Color {
-    RESET = 0,
-    BLUE = 34,
-    GREEN = 32,
-    RED = 31
-};
+    enum class Color {
+        RESET = 0,
+        BLUE = 34,
+        GREEN = 32,
+        RED = 31
+    };
 
 /**
  * @brief Level of logging
  * @TODO: Change this to be a flag in the CMakeLists.txt
  */
-const LogLevel LOGLEVEL = LogLevel::DEBUG;
+    const LogLevel LOGLEVEL = LogLevel::DEBUG;
 
 
 /// @brief Ensure that we only log when NDEBUG flg is not set
@@ -67,6 +69,7 @@ const LogLevel LOGLEVEL = LogLevel::DEBUG;
 
 #define LOG_FNC \
         "Function: " << __func__ << " "
+
 /**
  * @brief Logger class with colors and team names
  * @author @amantham20 @chatGPT
@@ -74,207 +77,204 @@ const LogLevel LOGLEVEL = LogLevel::DEBUG;
  * @details I was about to name this clogged.
  * @details This is a custom logger class that can be used to log messages to the console.
  */
-class Logger {
-public:
+    class Logger {
+    public:
 
-    /**
-     * @brief Sets the Team name for the current log
-     * 
-     * @param team name of the team
-     * @return Logger& 
-     */
-    Logger &operator<<(Team team) {
-        currentTeam = team;
-        metaPrinted = false;
-//         std::cout << endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
-        return *this;
-    }
-
-    /**
-     * @brief sets the log level for the current log
-     * 
-     * @param logLevel Level/Type of the log
-     * @return Logger& 
-     */
-    Logger &operator<<(LogLevel logLevel) {
-        currentLogLevel = logLevel;
-        metaPrinted = false;
-        return *this;
-    }
-
-
-
-    /**
-     * @brief colors of the log
-     * 
-     * @param color 
-     * @return Logger& 
-     */
-    Logger &operator<<(Color color) {
-        currentColor = color;
-        return *this;
-    }
-
-    /**
-     * @brief Manipulator for endl so that we can reset the values when a team is done logging
-     * 
-     * @param manipulator 
-     * @return Logger& 
-     */
-    Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
-
-        typedef std::ostream& (*EndlManipulator)(std::ostream&);
-
-        // Compare the function pointers
-        if (manipulator == static_cast<EndlManipulator>(std::endl)) {
-            // Handle std::endl here
-            currentTeam = Team::NA;
-            currentLogLevel = LogLevel::DEBUG;
-            currentColor = Color::RESET;
-            std::cout << std::endl;
-        }
-
-        if (manipulator == endl) {
-
-            currentTeam = Team::NA;
-            currentLogLevel = LogLevel::DEBUG;
-            currentColor = Color::RESET;
-
-            std::cout
-                    << std::endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
+        /**
+         * @brief Sets the Team name for the current log
+         *
+         * @param team name of the team
+         * @return Logger&
+         */
+        Logger &operator<<(Team team) {
+            currentTeam = team;
             metaPrinted = false;
+//         std::cout << endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
+            return *this;
         }
-        return *this;
-    }
 
-    /**
-     * @brief Aye I used a template.
-     * @brief Function to log the value
-     * 
-     * @tparam T 
-     * @param value 
-     * @return Logger& 
-     * 
-     * @TODO: Might have to change this so that we only break a team log when a new team is set. aka ensure that  logger << Team::TEAM_1 << "Hello" << "World" << endl; works in one line with one team print
-     */
-    template<typename T>
-    Logger &operator<<(const T &value) {
+        /**
+         * @brief sets the log level for the current log
+         *
+         * @param logLevel Level/Type of the log
+         * @return Logger&
+         */
+        Logger &operator<<(LogLevel logLevel) {
+            currentLogLevel = logLevel;
+            metaPrinted = false;
+            return *this;
+        }
 
 
-        //TODO: Define when to log by loglevel comparison. Goal is to send it in as a flag in the CMakeLists.txt
-        if (currentLogLevel >= LOGLEVEL) {
+        /**
+         * @brief colors of the log
+         *
+         * @param color
+         * @return Logger&
+         */
+        Logger &operator<<(Color color) {
+            currentColor = color;
+            return *this;
+        }
 
-            // added additional flag in case one wants to compile without colors (or) if the terminal does not support colors
-            #ifndef D_ANSI_COLOR_CODES
-            std::string colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
-            std::string colorEnd = "\033[0m";
-            #else
-            std::string colorStart = "";
-            std::string colorEnd = "";
-            #endif
-            std::ostringstream logMessage;
-            logMessage << colorStart;
-            if (!metaPrinted) {
-                logMessage << teamToString(currentTeam) << logToString(currentLogLevel);
-                metaPrinted = true;
+        /**
+         * @brief Manipulator for endl so that we can reset the values when a team is done logging
+         *
+         * @param manipulator
+         * @return Logger&
+         */
+        Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
+
+            typedef std::ostream &(*EndlManipulator)(std::ostream &);
+
+            // Compare the function pointers
+            if (manipulator == static_cast<EndlManipulator>(std::endl)) {
+                // Handle std::endl here
+                currentTeam = Team::NA;
+                currentLogLevel = LogLevel::DEBUG;
+                currentColor = Color::RESET;
+                std::cout << std::endl;
             }
 
-            logMessage << value << colorEnd;
-            std::cout
-                    << logMessage.str(); // << std::endl;  //TODO: Might have to make enable this so that we can have same line logging when endl is not used
+            if (manipulator == endl) {
+
+                currentTeam = Team::NA;
+                currentLogLevel = LogLevel::DEBUG;
+                currentColor = Color::RESET;
+
+                std::cout
+                        << std::endl; //TODO: Might have to enable this so that we can have same line logging when endl is not used
+                metaPrinted = false;
+            }
+            return *this;
         }
 
-        return *this;
-    }
+        /**
+         * @brief Aye I used a template.
+         * @brief Function to log the value
+         *
+         * @tparam T
+         * @param value
+         * @return Logger&
+         *
+         * @TODO: Might have to change this so that we only break a team log when a new team is set. aka ensure that  logger << Team::TEAM_1 << "Hello" << "World" << endl; works in one line with one team print
+         */
+        template<typename T>
+        Logger &operator<<(const T &value) {
 
 
-    static Logger log; /// Global log instance //TODO: Check if poluting the global namespace is a good idea??
+            //TODO: Define when to log by loglevel comparison. Goal is to send it in as a flag in the CMakeLists.txt
+            if (currentLogLevel >= LOGLEVEL) {
 
-    /**
-     * @brief Custom endl to reset the values
-     * 
-     * @param os 
-     * @return std::ostream& 
-     */
-    static std::ostream &endl(std::ostream &os) {
+                // added additional flag in case one wants to compile without colors (or) if the terminal does not support colors
+#ifndef D_ANSI_COLOR_CODES
+                std::string colorStart = "\033[" + std::to_string(static_cast<int>(currentColor)) + "m";
+                std::string colorEnd = "\033[0m";
+#else
+                std::string colorStart = "";
+                std::string colorEnd = "";
+#endif
+                std::ostringstream logMessage;
+                logMessage << colorStart;
+                if (!metaPrinted) {
+                    logMessage << teamToString(currentTeam) << logToString(currentLogLevel);
+                    metaPrinted = true;
+                }
 
-        log << std::endl; // Call the custom Logger::endl to reset values
-        return os;
-    }
+                logMessage << value << colorEnd;
+                std::cout
+                        << logMessage.str(); // << std::endl;  //TODO: Might have to make enable this so that we can have same line logging when endl is not used
+            }
 
-private:
-    /// @brief Current team for that is going to log
-    Team currentTeam = Team::NA;
-
-    /// @brief Current log level for the log
-    LogLevel currentLogLevel = LogLevel::DEBUG;
-
-    /// @brief Current color for the log
-    Color currentColor = Color::RESET;
-
-    bool metaPrinted = false;
-
-
-
-    /**
-     * @brief Map to convert Team enum to string
-     * 
-     */
-    std::map<Team, std::string> teamToStringMap = {
-            {Team::TEAM_1,  "Team 1"},
-            {Team::TEAM_2,  "Team 2"},
-            {Team::TEAM_3,  "Team 3"},
-            {Team::TEAM_4,  "Team 4"},
-            {Team::TEAM_5,  "Team 5"},
-            {Team::TEAM_6,  "Team 6"},
-            {Team::TEAM_7,  "Team 7"},
-            {Team::TEAM_8,  "Team 8"},
-            {Team::TEAM_9,  "Team 9"},
-            {Team::GENERAL, "General"}
-    };
-
-    /**
-     * @brief Converts Team enum to string
-     * 
-     * @param team 
-     * @return std::string 
-     */
-    std::string teamToString(Team team) {
-
-        auto it = teamToStringMap.find(team);
-        if (it != teamToStringMap.end()) {
-            return "[" + it->second + "]";
+            return *this;
         }
 
-        return "";
 
-    }
+        static Logger log; /// Global log instance //TODO: Check if poluting the global namespace is a good idea??
 
-    /**
-     * @brief Converts LogLevel enum to string
-     * 
-     * @param logLevel 
-     * @return std::string 
-     */
-    std::string logToString(LogLevel logLevel) {
-        if (logLevel == LogLevel::DEBUG) {
-            return "(DEBUG) ";
-        } else if (logLevel == LogLevel::INFO) {
-            return "(INFO) ";
-        } else if (logLevel == LogLevel::WARNING) {
-            return "(WARNING) ";
-        } else if (logLevel == LogLevel::ERROR) {
-            return "(ERROR) ";
-        } else {
+        /**
+         * @brief Custom endl to reset the values
+         *
+         * @param os
+         * @return std::ostream&
+         */
+        static std::ostream &endl(std::ostream &os) {
+
+            log << std::endl; // Call the custom Logger::endl to reset values
+            return os;
+        }
+
+    private:
+        /// @brief Current team for that is going to log
+        Team currentTeam = Team::NA;
+
+        /// @brief Current log level for the log
+        LogLevel currentLogLevel = LogLevel::DEBUG;
+
+        /// @brief Current color for the log
+        Color currentColor = Color::RESET;
+
+        bool metaPrinted = false;
+
+
+        /**
+         * @brief Map to convert Team enum to string
+         *
+         */
+        std::map<Team, std::string> teamToStringMap = {
+                {Team::TEAM_1,  "Team 1"},
+                {Team::TEAM_2,  "Team 2"},
+                {Team::TEAM_3,  "Team 3"},
+                {Team::TEAM_4,  "Team 4"},
+                {Team::TEAM_5,  "Team 5"},
+                {Team::TEAM_6,  "Team 6"},
+                {Team::TEAM_7,  "Team 7"},
+                {Team::TEAM_8,  "Team 8"},
+                {Team::TEAM_9,  "Team 9"},
+                {Team::GENERAL, "General"}
+        };
+
+        /**
+         * @brief Converts Team enum to string
+         *
+         * @param team
+         * @return std::string
+         */
+        std::string teamToString(Team team) {
+
+            auto it = teamToStringMap.find(team);
+            if (it != teamToStringMap.end()) {
+                return "[" + it->second + "]";
+            }
+
             return "";
-        }
-    }
-};
 
+        }
+
+        /**
+         * @brief Converts LogLevel enum to string
+         *
+         * @param logLevel
+         * @return std::string
+         */
+        std::string logToString(LogLevel logLevel) {
+            if (logLevel == LogLevel::DEBUG) {
+                return "(DEBUG) ";
+            } else if (logLevel == LogLevel::INFO) {
+                return "(INFO) ";
+            } else if (logLevel == LogLevel::WARNING) {
+                return "(WARNING) ";
+            } else if (logLevel == LogLevel::ERROR) {
+                return "(ERROR) ";
+            } else {
+                return "";
+            }
+        }
+    };
 
 
 /// @brief Global log instance
-Logger Logger::log;
+    Logger Logger::log;
 
 #else
 
@@ -283,23 +283,25 @@ Logger Logger::log;
 #define LOG_FNC ""
 
 
-class Logger {
-public:
-    template <typename T>
-    Logger& operator<<(const T& value) {
-        return *this;
-    }
+    class Logger {
+    public:
+        template <typename T>
+        Logger& operator<<(const T& value) {
+            return *this;
+        }
 
-    Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
-        return *this;
-    }
+        Logger &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
+            return *this;
+        }
 
-    static std::ostream &endl(std::ostream &os) {
-        return os;
-    }
+        static std::ostream &endl(std::ostream &os) {
+            return os;
+        }
 
-    static Logger log;
-};
+        static Logger log;
+    };
 
-Logger Logger::log;
+    Logger Logger::log;
 #endif
+
+}  // namespace

--- a/tests/unit/core/Logger.cpp
+++ b/tests/unit/core/Logger.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Logger class tests", "[Logger]") {
                          "\x1B[34mcont no endl Error message from Team\x1B[0m\n"
                          "\x1B[0m(DEBUG) Warning message standard overload\x1B[0m\n"
                          "\x1B[34m[Team 5](WARNING) Warning message from Team D.\x1B[0m\n");
-  }
+  
 
 #else
     REQUIRE(logOutput == "");

--- a/tests/unit/core/Logger.cpp
+++ b/tests/unit/core/Logger.cpp
@@ -1,0 +1,51 @@
+//
+// Created by Aman Dhruva Thamminana on 10/14/23.
+//
+
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+
+#include "core/EasyLogging.hpp"
+
+
+using namespace clogged;
+
+TEST_CASE("Logger class tests", "[Logger]") {
+  // Test case 1: Check if Logger can log messages with different log levels, teams, and colors
+  SECTION("Logger message logging") {
+    // Redirect standard output to a stringstream to capture the log messages
+    std::stringstream output;
+    auto old_cout = std::cout.rdbuf(output.rdbuf());
+
+    // Log messages
+    Logger::Log() << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE
+                           << "This is a debug message from Team A." << "aye 2" << Logger::endl;
+    Logger::Log() << Team::TEAM_2 << LogLevel::INFO << Color::GREEN
+                           << "This is an info message from Team B." << Logger::endl;
+    Logger::Log() << Team::TEAM_3 << LogLevel::ERROR << Color::RED
+                           << "RED Error message from Team C." << Logger::endl;
+    Logger::Log() << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE
+                           << "Error message from Team C. no endl";
+    Logger::Log() << "cont no endl Error message from Team";
+    Logger::Log() << std::endl << "Warning message standard overload" << std::endl;
+    Logger::Log() << Team::TEAM_5 << LogLevel::WARNING << Color::BLUE
+                           << "Warning message from Team D." << Logger::endl;
+
+    // Reset standard output
+    std::cout.rdbuf(old_cout);
+
+    // Get the captured log messages from the stringstream
+    std::string logOutput = output.str();
+
+    // Check if the log messages match the expected output
+    REQUIRE(logOutput == "\x1B[34m[Team 1](DEBUG) This is a debug message from Team A.\x1B[0m\x1B[34maye 2\x1B[0m\n"
+                         "\x1B[32m[Team 2](INFO) This is an info message from Team B.\x1B[0m\n"
+                         "\x1B[31m[Team 3](ERROR) RED Error message from Team C.\x1B[0m\n"
+                         "\x1B[34m[Team 4](ERROR) Error message from Team C. no endl\x1B[0m"
+                         "\x1B[34mcont no endl Error message from Team\x1B[0m\n"
+                         "\x1B[0m(DEBUG) Warning message standard overload\x1B[0m\n"
+                         "\x1B[34m[Team 5](WARNING) Warning message from Team D.\x1B[0m\n");
+  }
+}

--- a/tests/unit/core/Logger.cpp
+++ b/tests/unit/core/Logger.cpp
@@ -14,6 +14,7 @@ using namespace clogged;
 
 TEST_CASE("Logger class tests", "[Logger]") {
   // Test case 1: Check if Logger can log messages with different log levels, teams, and colors
+
   SECTION("Logger message logging") {
     // Redirect standard output to a stringstream to capture the log messages
     std::stringstream output;
@@ -21,24 +22,24 @@ TEST_CASE("Logger class tests", "[Logger]") {
 
     // Log messages
     Logger::Log() << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE
-                           << "This is a debug message from Team A." << "aye 2" << Logger::endl;
+                  << "This is a debug message from Team A." << "aye 2" << Logger::endl;
     Logger::Log() << Team::TEAM_2 << LogLevel::INFO << Color::GREEN
-                           << "This is an info message from Team B." << Logger::endl;
+                  << "This is an info message from Team B." << Logger::endl;
     Logger::Log() << Team::TEAM_3 << LogLevel::ERROR << Color::RED
-                           << "RED Error message from Team C." << Logger::endl;
+                  << "RED Error message from Team C." << Logger::endl;
     Logger::Log() << Team::TEAM_4 << LogLevel::ERROR << Color::BLUE
-                           << "Error message from Team C. no endl";
+                  << "Error message from Team C. no endl";
     Logger::Log() << "cont no endl Error message from Team";
     Logger::Log() << std::endl << "Warning message standard overload" << std::endl;
     Logger::Log() << Team::TEAM_5 << LogLevel::WARNING << Color::BLUE
-                           << "Warning message from Team D." << Logger::endl;
+                  << "Warning message from Team D." << Logger::endl;
 
     // Reset standard output
     std::cout.rdbuf(old_cout);
 
     // Get the captured log messages from the stringstream
     std::string logOutput = output.str();
-
+#ifndef NDEBUG
     // Check if the log messages match the expected output
     REQUIRE(logOutput == "\x1B[34m[Team 1](DEBUG) This is a debug message from Team A.\x1B[0m\x1B[34maye 2\x1B[0m\n"
                          "\x1B[32m[Team 2](INFO) This is an info message from Team B.\x1B[0m\n"
@@ -48,4 +49,11 @@ TEST_CASE("Logger class tests", "[Logger]") {
                          "\x1B[0m(DEBUG) Warning message standard overload\x1B[0m\n"
                          "\x1B[34m[Team 5](WARNING) Warning message from Team D.\x1B[0m\n");
   }
+
+#else
+    REQUIRE(logOutput == "");
+#endif
+  }
+
 }
+

--- a/tests/unit/core/targets.txt
+++ b/tests/unit/core/targets.txt
@@ -1,2 +1,3 @@
 Data
 WorldGrid
+Logger


### PR DESCRIPTION
As we expand our codebases, we will probably have to debug a lot thereby we will run into the issue of placing print statements everywhere. So similar to having tests like `assert` that can be removed I thought having a class for logging would be nice. 

**_we could alternatively use an open-source library._**


here are some current features:

- setting team number
- setting log status [debug, info, warning, error]
- setting colors of print statements.
- Does not compile in RELEASE


addition features to add.
- logging to a file
- adding flags for debuging in cmake.
- making it run on a different thread/ running it Asynchronously?. Especially helpful for improving performance and responsiveness 
    - cuz of the io operation or if we want to send stuff thru the network
- More log levels like `Fatal` or `Trace`
- Categorization and filtering thru flags


Here is an example


```cpp
    // Example 1: Logging a debug message for Team 1 in blue color
    Logger::log << Team::TEAM_1 << LogLevel::DEBUG << Color::BLUE << "Debug message for Team 1" << Logger::endl;

    // Example 2: Logging an error message for Team 5 in red color
    Logger::log << Team::TEAM_5 << LogLevel::ERROR << Color::RED << "Error message for Team 5" << Logger::endl;

    // Example 3: Logging an info message for General team in green color
    Logger::log << Team::GENERAL << LogLevel::INFO << Color::GREEN << "Info message for General team" << Logger::endl;

    // Example 4: Logging a warning message without specifying team and color
    Logger::log << LogLevel::WARNING << "Generic warning message" << Logger::endl;
```

and here is a sample output

<img width="427" alt="image" src="https://github.com/MSU-CSE491/cse_491_fall_2023/assets/48414198/e2f2dce6-6b00-4e53-b815-66cc9bff3260">

 
Feel free to add in anything else.


![giphy (2)](https://github.com/MSU-CSE491/cse_491_fall_2023/assets/48414198/53409fa1-9eee-4b51-ba35-9df62187a449)
