### PR TITLE
Adjusted properties to be of any type

### DIFF
--- a/source/Interfaces/TrashInterface.hpp
+++ b/source/Interfaces/TrashInterface.hpp
@@ -41,8 +41,8 @@ namespace cse491 {
       for (const auto & agent_ptr : agent_set) {
         GridPosition pos = agent_ptr->GetPosition();
         char c = '*';
-        if(agent_ptr->HasProperty("char")){
-          c = static_cast<char>(agent_ptr->GetProperty("char"));
+        if(agent_ptr->HasProperty("symbol")){
+          c = agent_ptr->GetProperty<char>("symbol");
         }
         symbol_grid[pos.CellY()][pos.CellX()] = c;
       }

--- a/source/simple_main.cpp
+++ b/source/simple_main.cpp
@@ -14,7 +14,7 @@ int main()
   cse491::MazeWorld world;
   world.AddAgent<cse491::PacingAgent>("Pacer 1").SetPosition(3,1);
   world.AddAgent<cse491::PacingAgent>("Pacer 2").SetPosition(6,1);
-  world.AddAgent<cse491::TrashInterface>("Interface").SetProperty("char", '@');
+  world.AddAgent<cse491::TrashInterface>("Interface").SetProperty("symbol", '@');
 
   world.Run();
 }


### PR DESCRIPTION
Previously, all properties had to be type `double`.  Now they will still default to double, but module developers may set the properties to be of any type of their choice, as long as they match the type for all future uses of that property name.
