### PR TITLE
Modify CellType to support properties

### DIFF
--- a/source/Worlds/MazeWorld.hpp
+++ b/source/Worlds/MazeWorld.hpp
@@ -29,8 +29,12 @@ class MazeWorld : public WorldBase {
 
  public:
   MazeWorld() {
+    // Create cell types
     floor_id = AddCellType("floor", "Floor that you can easily walk over.", ' ');
     wall_id = AddCellType("wall", "Impenetrable wall that you must find a way around.", '#');
+    // Set cell type properties
+    type_options.at(floor_id).SetProperty(CellType::CELL_WALL);
+    // Load map
     main_grid.Read("../assets/grids/default_maze.grid", type_options);
   }
   ~MazeWorld() = default;
@@ -54,7 +58,7 @@ class MazeWorld : public WorldBase {
 
     // Don't let the agent move off the world or into a wall.
     if (!main_grid.IsValid(new_position)) { return false; }
-    if (main_grid.At(new_position) == wall_id) { return false; }
+    if (!IsTraversable(agent, new_position)) { return false; }
 
     // Set the agent to its new postion.
     agent.SetPosition(new_position);
@@ -63,7 +67,7 @@ class MazeWorld : public WorldBase {
 
   /// Can walk on all tiles except for walls
   bool IsTraversable(const AgentBase & /*agent*/, cse491::GridPosition pos) const override {
-    return main_grid.At(pos) != wall_id;
+    return GetCellTypes().at(main_grid.At(pos)).HasProperty(CellType::CELL_WALL);
   }
 };
 

--- a/source/core/Data.hpp
+++ b/source/core/Data.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <set>
 
 namespace cse491 {
   
@@ -18,6 +19,26 @@ namespace cse491 {
     std::string name;  ///< Unique name for this type of cell (e.g., "wall", "tree", "moon")
     std::string desc;  ///< Full description of what this type of cell is
     char symbol;       ///< Symbol for text representations (files or interface)
+    std::set<std::string> properties{}; ///< Set of properties for this cell type.
+    
+    /// Adds the specifed property to this CellType.
+    CellType& SetProperty(const std::string& property){
+      properties.insert(property);
+      return *this;
+    }
+    
+    /// Removes the specifed property from this CellType.
+    CellType& RemoveProperty(const std::string& property){
+      properties.erase(property);
+      return *this;
+    }
+    
+    /// Checks if the given property is set on this CellType.
+    bool HasProperty(const std::string& property) const {
+      return properties.count(property);
+    }
+    
+    constexpr static std::string CELL_WALL = "wall";
   };
 
   /// @brief Available CellTypes will be passed around as a vector of options.

--- a/source/core/Data.hpp
+++ b/source/core/Data.hpp
@@ -39,6 +39,7 @@ namespace cse491 {
     }
     
     constexpr static std::string CELL_WALL = "wall";
+    constexpr static std::string CELL_WATER = "water";
   };
 
   /// @brief Available CellTypes will be passed around as a vector of options.

--- a/tests/unit/core/Data.cpp
+++ b/tests/unit/core/Data.cpp
@@ -18,3 +18,35 @@ TEST_CASE("CellType", "[core]"){
   CHECK(cell_type.desc == "desc");
   CHECK(cell_type.symbol == '@');
 }
+
+TEST_CASE("CellType properties", "[core]"){
+  // Regular values test
+  cse491::CellType cell_type{"test", "test description", '^'};
+  CHECK(cell_type.name == "test");
+  CHECK(cell_type.desc == "test description");
+  CHECK(cell_type.symbol == '^');
+  // Add properties
+  cell_type.SetProperty("prop1");
+  cell_type.SetProperty("prop2");
+  cell_type.SetProperty("prop3");
+  // Check properties were added
+  CHECK(cell_type.HasProperty("prop1"));
+  CHECK(cell_type.HasProperty("prop2"));
+  CHECK(cell_type.HasProperty("prop3"));
+  // Remove properties
+  cell_type.RemoveProperty("prop2");
+  cell_type.RemoveProperty("prop3");
+  // Check properties were removed
+  CHECK(cell_type.HasProperty("prop1"));
+  CHECK_FALSE(cell_type.HasProperty("prop2"));
+  CHECK_FALSE(cell_type.HasProperty("prop3"));
+  // Chaining adds and removals
+  cell_type.RemoveProperty("prop1").SetProperty("prop3").SetProperty("prop4");
+  // Check that changes worked
+  CHECK_FALSE(cell_type.HasProperty("prop1"));
+  CHECK_FALSE(cell_type.HasProperty("prop2"));
+  CHECK(cell_type.HasProperty("prop3"));
+  CHECK(cell_type.HasProperty("prop4"));
+  
+  
+}


### PR DESCRIPTION
Adds a std::set containing std::strings respresenting binary properties
Adds methods SetProperty,RemoveProperty,HasProperty. SetProperty and RemoveProperty can be chained
Adds one constant CELL_WALL to cell type (this marks tiles that are impassible).
Modifies MazeWorld to use properties instead of saved ids for traversal check
Adds tests for CellType property methods.

All tests were passing and MazeWorld behaved as expected when I tested locally.